### PR TITLE
Fix version of stripe-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     ],
     "require": {
         "payum/core": "^1.5",
-        "php-http/guzzle6-adapter": "^1.0"
+        "php-http/guzzle6-adapter": "^1.0",
+        "stripe/stripe-php": "^6.29"
     },
     "config": {
         "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "payum/core": "^1.5",
         "php-http/guzzle6-adapter": "^1.0",
-        "stripe/stripe-php": "^6.29"
+        "stripe/stripe-php": "^6.38"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
As described in this post : https://github.com/Payum/Payum/issues/804#issuecomment-508049228 
The session class used is only available since v6.29.0 of stripe-php 
https://github.com/stripe/stripe-php/blob/v6.29.0/lib/Checkout/Session.php

Some constants used are only available since v6.37.2 of stripe-php
https://github.com/stripe/stripe-php/blob/v6.37.2/lib/Checkout/Session.php