### PR TITLE
Patch 2

### DIFF
--- a/src/Action/Api/CheckPaymentAction.php
+++ b/src/Action/Api/CheckPaymentAction.php
@@ -1,0 +1,93 @@
+<?php
+namespace Combodo\StripeV3\Action\Api;
+
+use Combodo\StripeV3\Request\Api\CheckPayment;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\ApiAwareInterface;
+use Payum\Core\ApiAwareTrait;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\GatewayAwareInterface;
+use Payum\Core\GatewayAwareTrait;
+use Payum\Core\Reply\HttpResponse;
+use Payum\Core\Request\GetHttpRequest;
+use Payum\Core\Request\RenderTemplate;
+use Combodo\StripeV3\Keys;
+use Combodo\StripeV3\Request\Api\ObtainToken;
+use Stripe\Checkout\Session;
+use Stripe\Stripe;
+
+/**
+ * @property Keys $keys alias of $api
+ * @property Keys $api
+ */
+class CheckPaymentAction implements ActionInterface, GatewayAwareInterface, ApiAwareInterface
+{
+    use ApiAwareTrait {
+        setApi as _setApi;
+    }
+    use GatewayAwareTrait;
+
+    /**
+     * @var string
+     */
+    protected $templateName;
+
+    /**
+     * @deprecated BC will be removed in 2.x. Use $this->api
+     *
+     * @var Keys
+     */
+    protected $keys;
+
+    /**
+     * CheckPaymentAction constructor.
+     */
+    public function __construct()
+    {
+
+        $this->apiClass = Keys::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setApi($api)
+    {
+        $this->_setApi($api);
+
+        // Has more meaning than api since it is just the api keys!
+        $this->keys = $this->api;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute($request)
+    {
+        /** @var $request ObtainToken */
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $model = ArrayObject::ensureArrayObject($request->getModel());
+
+
+        Stripe::setApiKey($this->keys->getSecretKey());
+        if (!empty($model['session_id'])) {
+            $session = \Stripe\Checkout\Session::retrieve($model['session_id']);
+            $payment_intent = \Stripe\PaymentIntent::retrieve($session->payment_intent);
+            $model['status'] = $payment_intent->status;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof CheckPayment &&
+            $request->getModel() instanceof \ArrayObject
+        ;
+    }
+}

--- a/src/Action/Api/ObtainTokenAction.php
+++ b/src/Action/Api/ObtainTokenAction.php
@@ -71,6 +71,8 @@ class ObtainTokenAction implements ActionInterface, GatewayAwareInterface, ApiAw
 
         $model = ArrayObject::ensureArrayObject($request->getModel());
 
+
+        Stripe::setApiKey($this->keys->getSecretKey());
         if (empty($model['session_id'])) {
             $session = $this->obtainSession($request, $model);
 
@@ -106,24 +108,19 @@ class ObtainTokenAction implements ActionInterface, GatewayAwareInterface, ApiAw
      */
     private function obtainSession(ObtainToken $request, ArrayObject $model): Session
     {
-        Stripe::setApiKey($this->keys->getSecretKey());
 
-        // a note about the url: Pyaum know only 3 url:
-        // - prepare
-        // - capture : https://github.com/Payum/Payum/blob/master/docs/examples/capture-script.md
-        // - after : https://github.com/Payum/Payum/blob/master/docs/examples/done-script.md
-        // in fact, there is also the possibility of a webhook : https://github.com/Payum/Payum/blob/master/docs/examples/notify-script.md
+
         $session = Session::create(
             [
-                'success_url'           => $request->getToken()->getAfterUrl(), //@TODO : could not find any doc about what to use => check if my guess is good
-                'cancel_url'            => $request->getToken()->getAfterUrl(),  //@TODO : could not find any doc about what to use => check if my guess is good
+                'success_url'           => $request->getToken()->getTargetUrl() . '?status=success',
+                'cancel_url'            => $request->getToken()->getTargetUrl() . '?status=canceled',
                 'payment_method_types'  => ['card'],
                 'submit_type'           => Session::SUBMIT_TYPE_PAY,
                 'line_items'            => $model['line_items'],
                 'payment_intent_data'   => [
                     'metadata'              => $model['metadata'] ?? ['payment_id' => $model['id']],
                 ],
-                'client_reference_id'   => $request->getToken()->getHash(),      //the token hash is used to let Stripe detect when we call it several time about the same capture
+                'client_reference_id'   => $request->getToken()->getHash(),
             ]
         );
 

--- a/src/Action/CaptureAction.php
+++ b/src/Action/CaptureAction.php
@@ -1,6 +1,7 @@
 <?php
 namespace Combodo\StripeV3\Action;
 
+use Combodo\StripeV3\Request\Api\CheckPayment;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\GatewayAwareInterface;
@@ -9,6 +10,8 @@ use Payum\Core\Request\Capture;
 use Payum\Core\Exception\RequestNotSupportedException;
 use Combodo\StripeV3\Request\Api\CreateCharge;
 use Combodo\StripeV3\Request\Api\ObtainToken;
+use Payum\Core\Request\GetHttpRequest;
+use Stripe\Stripe;
 
 class CaptureAction implements ActionInterface, GatewayAwareInterface
 {
@@ -24,7 +27,14 @@ class CaptureAction implements ActionInterface, GatewayAwareInterface
         RequestNotSupportedException::assertSupports($this, $request);
 
         $model = ArrayObject::ensureArrayObject($request->getModel());
-
+        $getHttpRequest = new GetHttpRequest();
+        $this->gateway->execute($getHttpRequest);
+        if ($getHttpRequest->method == 'GET' && isset($getHttpRequest->query['status'])) {
+            $obtainToken = new CheckPayment($request->getToken());
+            $obtainToken->setModel($model);
+            $this->gateway->execute($obtainToken);
+            return;
+        }
         if ($model['status']) {
             return;
         }

--- a/src/Action/RefundAction.php
+++ b/src/Action/RefundAction.php
@@ -55,9 +55,6 @@ class RefundAction implements ActionInterface, ApiAwareInterface
 
         try {
             Stripe::setApiKey($this->keys->getSecretKey());
-//            $ch = StripeRefund::retrieve($model['id']);
-//            $refund = $ch->refunds->create(array('amount' => 100));
-//            $refund = StripeRefund::create($model->toUnsafeArrayWithoutLocal());
             $session = \Stripe\Checkout\Session::retrieve($model['session_id']);
             $intent = \Stripe\PaymentIntent::retrieve($session->payment_intent);
             $intent->charges->data[0]->refund();

--- a/src/Action/RefundAction.php
+++ b/src/Action/RefundAction.php
@@ -1,0 +1,80 @@
+<?php
+namespace Combodo\StripeV3\Action;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\ApiAwareInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\LogicException;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Exception\UnsupportedApiException;
+use Combodo\StripeV3\Keys;
+use Payum\Core\Request\Refund;
+use Stripe\Charge as Stripe_Charge;
+use Stripe\Refund as StripeRefund;
+use Stripe\Error;
+use Stripe\Stripe;
+use Combodo\StripeV3\Constants;
+
+class RefundAction implements ActionInterface, ApiAwareInterface
+{
+    /**
+     * @var Keys
+     */
+    protected $keys;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setApi($api)
+    {
+        if (false == $api instanceof Keys) {
+            throw new UnsupportedApiException('Not supported.');
+        }
+
+        $this->keys = $api;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute($request)
+    {
+        /** @var $request Refund */
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $model = ArrayObject::ensureArrayObject($request->getModel());
+        if (!@$model['session_id']) {
+            throw new LogicException('The session id has to be set.');
+        }
+
+        if (isset($model['amount'])
+            && (!is_numeric($model['amount']) || $model['amount'] <= 0)
+        ) {
+            throw new LogicException('The amount is invalid.');
+        }
+
+        try {
+            Stripe::setApiKey($this->keys->getSecretKey());
+//            $ch = StripeRefund::retrieve($model['id']);
+//            $refund = $ch->refunds->create(array('amount' => 100));
+//            $refund = StripeRefund::create($model->toUnsafeArrayWithoutLocal());
+            $session = \Stripe\Checkout\Session::retrieve($model['session_id']);
+            $intent = \Stripe\PaymentIntent::retrieve($session->payment_intent);
+            $intent->charges->data[0]->refund();
+            $refund = $model['refunded'] = true;
+        } catch (Error\Base $e) {
+            $model->replace($e->getJsonBody());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof Refund &&
+            $request->getModel() instanceof \ArrayAccess
+            ;
+    }
+}

--- a/src/Action/StatusAction.php
+++ b/src/Action/StatusAction.php
@@ -5,7 +5,7 @@ use Payum\Core\Action\ActionInterface;
 use Payum\Core\Request\GetStatusInterface;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Exception\RequestNotSupportedException;
-use Combodo\StripeV3;
+use Combodo\StripeV3\Constants;
 
 class StatusAction implements ActionInterface
 {
@@ -50,26 +50,14 @@ class StatusAction implements ActionInterface
             return;
         }
 
-        if (Constants::STATUS_SUCCEEDED == $model['status'] && $model['captured'] && $model['paid']) {
+        if (Constants::STATUS_SUCCEEDED == $model['status']) {
             $request->markCaptured();
 
             return;
         }
 
-        if (Constants::STATUS_PAID == $model['status'] && $model['captured'] && $model['paid']) {
+        if (Constants::STATUS_PAID == $model['status']) {
             $request->markCaptured();
-
-            return;
-        }
-
-
-        if (Constants::STATUS_SUCCEEDED == $model['status'] && false == $model['captured']) {
-            $request->markAuthorized();
-
-            return;
-        }
-        if (Constants::STATUS_PAID == $model['status'] && false == $model['captured']) {
-            $request->markAuthorized();
 
             return;
         }

--- a/src/Request/Api/CheckPayment.php
+++ b/src/Request/Api/CheckPayment.php
@@ -1,0 +1,8 @@
+<?php
+namespace Combodo\StripeV3\Request\Api;
+
+use Payum\Core\Request\Generic;
+
+class CheckPayment extends Generic
+{
+}

--- a/src/StripeV3GatewayFactory.php
+++ b/src/StripeV3GatewayFactory.php
@@ -1,6 +1,7 @@
 <?php
 namespace Combodo\StripeV3;
 
+use Combodo\StripeV3\Action\Api\CheckPaymentAction;
 use Combodo\StripeV3\Action\Api\CreateTokenAction;
 use Combodo\StripeV3\Action\Api\ObtainTokenAction;
 use Combodo\StripeV3\Action\Api\PollFullfilledPaymentsAction;
@@ -15,6 +16,7 @@ use Combodo\StripeV3\Action\NotifyAction;
 use Combodo\StripeV3\Action\NotifyUnsafeAction;
 use Combodo\StripeV3\Action\RefundAction;
 use Combodo\StripeV3\Action\StatusAction;
+use Combodo\StripeV3\Request\Api\CheckPayment;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\GatewayFactory;
 
@@ -40,8 +42,10 @@ class StripeV3GatewayFactory extends GatewayFactory
             'payum.action.obtain_token' => function (ArrayObject $config) {             // stripe specific action
                 return new ObtainTokenAction($config['payum.template.obtain_token']);
             },        // stripe specific action + injection of configuration!
+            'payum.action.check_payment' => new CheckPaymentAction(),                         // stripe specific action + injection of configuration!
+            'payum.action.notify_unsafe' => new NotifyUnsafeAction(),                   // modified standard action to handle "unsafe" ie without the token webhooks,
 
-            'payum.action.notify_unsafe' => new NotifyUnsafeAction(),                   // modified standard action to handle "unsafe" ie without the token webhooks
+            'payum.action.refund' => new RefundAction(),
 
             'payum.action.poll_fullfilled_payements' => new PollFullfilledPaymentsAction(), // custom action
             'payum.action.handle_lost_payements'     => new HandleLostPaymentsAction(),     // custom action


### PR DESCRIPTION
This PR is linked to the issue https://github.com/Combodo/CombodoPayumStripe/issues/2

There is several changements : 

- Using the targetUrl (capture route) in the obtainTokenAction instead of the afterUrl as success_url & cancel_url in order to recover the payment status directly after the payment.
- Add a condition in the captureAction in order to catch the request when the payment is done
- Add a new CheckPayment action
- Add a RefundAction
- Fix the missing class "Constants" in StatusAction
- Remove some conditions to allow the payment to be captured in StatusAction
