### PR TITLE
Allow payment intent data to be passed from the model

### DIFF
--- a/src/Action/Api/ObtainTokenAction.php
+++ b/src/Action/Api/ObtainTokenAction.php
@@ -132,6 +132,10 @@ class ObtainTokenAction implements ActionInterface, GatewayAwareInterface, ApiAw
             $params['customer_email'] = $model['customer_email'];
         }
 
+        if (isset($model['payment_intent_data'])) {
+            $params['payment_intent_data'] = array_merge($params['payment_intent_data'], $model['payment_intent_data']);
+        }
+
         $session = Session::create($params);
 
         return $session;


### PR DESCRIPTION
Hi!

I had a use case on a website where I needed the new gateway version which worked great with your code but I also needed to be able to specify a Connect account as the payment destination as well as specifying application fees.

So I just made an adjustment to the `ObtainTokenAction` to allow the `payment_intent_data` options to be added to the `Session` request.