### PR TITLE
Update php version required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.1",
         "payum/core": "^1.5",
         "php-http/guzzle6-adapter": "^1.0",
         "stripe/stripe-php": "^6.38"


### PR DESCRIPTION
It seems there is no need of a hard dependency on the 7.2 version of php.


Would it be ok to set it to 7.1 ?